### PR TITLE
full-width to time elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,6 +28,10 @@ article * {
 article.time {
     background: none;
     justify-content: center;
+    width: 100% !important;
+    width: -moz-available !important;
+    width: -webkit-fill-available !important;
+    width: fill-available !important;
 }
 article.time p {
     text-align: center;


### PR DESCRIPTION
make time elements full-width dividers to provide better overview per slot:

![Screenshot from 2019-12-29 14-02-07](https://user-images.githubusercontent.com/476060/71557254-05b34980-2a44-11ea-9f53-c2a33e37361b.png)
